### PR TITLE
Class list support for Completion#type

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -30,9 +30,13 @@ export interface Completion {
   /// library defines simple icons for `class`, `constant`, `enum`,
   /// `function`, `interface`, `keyword`, `method`, `namespace`,
   /// `property`, `text`, `type`, and `variable`.
-  /// If an array is provided, all class names are added to the
-  /// icon element without the `"cm-completionIcon-"` prefix.
-  type?: string | string[],
+  ///
+  /// Multiple classes can be provided by separating them with spaces.
+  type?: string,
+  /// Changes the class prefix of the type option. Defaults to
+  /// `cm-completionIcon-` if not set. The prefix can be disabled
+  /// by setting it to an empty string.
+  typeClassPrefix?: string,
   /// When given, should be a number from -99 to 99 that adjusts how
   /// this completion is ranked compared to other completions that
   /// match the input as well as this one. A negative number moves it

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -30,7 +30,9 @@ export interface Completion {
   /// library defines simple icons for `class`, `constant`, `enum`,
   /// `function`, `interface`, `keyword`, `method`, `namespace`,
   /// `property`, `text`, `type`, and `variable`.
-  type?: string,
+  /// If an array is provided, all class names are added to the
+  /// icon element without the `"cm-completionIcon-"` prefix.
+  type?: string | string[],
   /// When given, should be a number from -99 to 99 that adjusts how
   /// this completion is ranked compared to other completions that
   /// match the input as well as this one. A negative number moves it

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -33,10 +33,6 @@ export interface Completion {
   ///
   /// Multiple classes can be provided by separating them with spaces.
   type?: string,
-  /// Changes the class prefix of the type option. Defaults to
-  /// `cm-completionIcon-` if not set. The prefix can be disabled
-  /// by setting it to an empty string.
-  typeClassPrefix?: string,
   /// When given, should be a number from -99 to 99 that adjusts how
   /// this completion is ranked compared to other completions that
   /// match the input as well as this one. A negative number moves it

--- a/src/tooltip.ts
+++ b/src/tooltip.ts
@@ -17,7 +17,9 @@ function createListBox(options: readonly Option[], id: string, range: {from: num
     li.id = id + "-" + i
     let icon = li.appendChild(document.createElement("div"))
     icon.classList.add("cm-completionIcon")
-    if (completion.type) icon.classList.add("cm-completionIcon-" + completion.type)
+    if (completion.type)
+      if (typeof completion.type === "string") icon.classList.add("cm-completionIcon-" + completion.type)
+      else icon.classList.add(...completion.type)
     icon.setAttribute("aria-hidden", "true")
     let labelElt = li.appendChild(document.createElement("span"))
     labelElt.className = "cm-completionLabel"

--- a/src/tooltip.ts
+++ b/src/tooltip.ts
@@ -17,10 +17,8 @@ function createListBox(options: readonly Option[], id: string, range: {from: num
     li.id = id + "-" + i
     let icon = li.appendChild(document.createElement("div"))
     icon.classList.add("cm-completionIcon")
-    if (completion.type) {
-      const prefix = completion.typeClassPrefix ?? "cm-completionIcon-";
-      icon.classList.add(...completion.type.split(/\s+/g).map(cls => prefix + cls))
-    }
+    if (completion.type)
+      icon.classList.add(...completion.type.split(/\s+/g).map(cls => "cm-completionIcon-" + cls))
     icon.setAttribute("aria-hidden", "true")
     let labelElt = li.appendChild(document.createElement("span"))
     labelElt.className = "cm-completionLabel"

--- a/src/tooltip.ts
+++ b/src/tooltip.ts
@@ -17,9 +17,10 @@ function createListBox(options: readonly Option[], id: string, range: {from: num
     li.id = id + "-" + i
     let icon = li.appendChild(document.createElement("div"))
     icon.classList.add("cm-completionIcon")
-    if (completion.type)
-      if (typeof completion.type === "string") icon.classList.add("cm-completionIcon-" + completion.type)
-      else icon.classList.add(...completion.type)
+    if (completion.type) {
+      const prefix = completion.typeClassPrefix ?? "cm-completionIcon-";
+      icon.classList.add(...completion.type.split(/\s+/g).map(cls => prefix + cls))
+    }
     icon.setAttribute("aria-hidden", "true")
     let labelElt = li.appendChild(document.createElement("span"))
     labelElt.className = "cm-completionLabel"


### PR DESCRIPTION
This pull request allows supplying the `Completion#type` with an array of class names that are added to the icon `<div>` element without a prefix. This allows more CSS styling using selectors.

Example: You want an icon with decorations (a Java class can be final or static etc.). To avoid having to create a new class for every possible combination of modifiers and types, it would now be possible to add a class for each modifier, like "icon-final" or "icon-static" that can be combined: `{ label: "MyClass", type: ["icon", "type-icon", "icon-class", "icon-final"] }`.

I was unable to actually test this PR because the cm-buildhelper throws an internal error for me.