### PR TITLE
Add ifIn, the complement of ifNotIn

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -16,6 +16,8 @@
 
 @completeFromList
 
+@ifIn
+
 @ifNotIn
 
 @completeAnyWord

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -120,6 +120,16 @@ export function completeFromList(list: readonly (string | Completion)[]): Comple
   }
 }
 
+/// Wrap the given completion source so that it will only fire when the
+/// cursor is in a syntax node with one of the given names.
+export function ifIn(nodes: readonly string[], source: CompletionSource): CompletionSource {
+  return (context: CompletionContext) => {
+    for (let pos: SyntaxNode | null = syntaxTree(context.state).resolve(context.pos, -1); pos; pos = pos.parent)
+      if (nodes.indexOf(pos.name) > -1) return source(context)
+    return null
+  }
+}
+
 /// Wrap the given completion source so that it will not fire when the
 /// cursor is in a syntax node with one of the given names.
 export function ifNotIn(nodes: readonly string[], source: CompletionSource): CompletionSource {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import {completionPlugin, moveCompletionSelection, acceptCompletion, startComple
 import {baseTheme} from "./theme"
 
 export {snippet, snippetCompletion, nextSnippetField, prevSnippetField, clearSnippet, snippetKeymap} from "./snippet"
-export {Completion, CompletionContext, CompletionSource, CompletionResult, completeFromList, ifNotIn} from "./completion"
+export {Completion, CompletionContext, CompletionSource, CompletionResult, completeFromList, ifIn, ifNotIn} from "./completion"
 export {startCompletion, closeCompletion, acceptCompletion, moveCompletionSelection} from "./view"
 export {completeAnyWord} from "./word"
 


### PR DESCRIPTION
I needed to show some autocompletions _only_ when inside a certain node for [Jobsort](https://www.jobsort.com/), rather than show autocompletions when not in certain nodes. This pull request adds a new function `ifIn` which acts as the reverse of `ifNotIn`. Might as well contribute the `ifIn` function upstream as it might be useful to others too.