### PR TITLE
Fix aria attributes to make it spec compliant

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -128,14 +128,13 @@ function sameResults(a: readonly ActiveSource[], b: readonly ActiveSource[]) {
 }
 
 const baseAttrs = {
-  "aria-autocomplete": "list",
-  "aria-expanded": "false"
+  "aria-autocomplete": "list"
 }
 
 function makeAttrs(id: string, selected: number): {[name: string]: string} {
   return {
     "aria-autocomplete": "list",
-    "aria-expanded": "true",
+    "aria-haspopup":"listbox",
     "aria-activedescendant": id + "-" + selected,
     "aria-controls": id
   }

--- a/src/tooltip.ts
+++ b/src/tooltip.ts
@@ -196,6 +196,7 @@ class CompletionTooltip {
     const ul = document.createElement("ul")
     ul.id = id
     ul.setAttribute("role", "listbox")
+    ul.setAttribute("aria-expanded", "true")
     for (let i = range.from; i < range.to; i++) {
       let {completion, match} = options[i]
       const li = ul.appendChild(document.createElement("li"))


### PR DESCRIPTION
This will address the issue related to the correct use of `aria-expanded` and `aria-haspopup` attributes to make it [spec](https://www.w3.org/TR/wai-aria/#aria-autocomplete) compliant. The issue is also mentioned [here](https://discuss.codemirror.net/t/accessibility-warning-in-chrome-lighthouse-report/3950) 

I came across this while using this awesome library.

<img width="500" alt="Screenshot 2022-03-09 at 17 36 10" src="https://user-images.githubusercontent.com/5461414/157487172-03679a3d-69e3-41d4-ab26-12e30bb3b7f9.png">
