### PR TITLE
Allow mouse option selection

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -39,6 +39,9 @@ export interface CompletionConfig {
   /// 70.
   addToOptions?: {render: (completion: Completion, state: EditorState) => Node | null,
                   position: number}[]
+  /// When enabled (defaults to false), the mouse will be used to select 
+  /// an autocomplete result when hovering
+  allowMouseSelection?:boolean
 }
 
 export const completionConfig = Facet.define<CompletionConfig, Required<CompletionConfig>>({
@@ -51,7 +54,8 @@ export const completionConfig = Facet.define<CompletionConfig, Required<Completi
       optionClass: () => "",
       aboveCursor: false,
       icons: true,
-      addToOptions: []
+      addToOptions: [],
+      allowMouseSelection: false
     }, {
       defaultKeymap: (a, b) => a && b,
       icons: (a, b) => a && b,


### PR DESCRIPTION
This will allow users to set a new configuration option `allowMouseSelection`, to change the current selected item on a suggestions list based on mouse hover. It does not change any behavior on the keyboard selection so both can be used at the same time.

https://user-images.githubusercontent.com/5461414/159241885-6605a4a9-9ce0-4b85-844b-3c7c33cef264.mov


