### PR TITLE
Allow resolving null from completion info promise

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -16,7 +16,7 @@ export interface Completion {
   /// Additional info to show when the completion is selected. Can be
   /// a plain string or a function that'll render the DOM structure to
   /// show when invoked.
-  info?: string | ((completion: Completion) => (Node | Promise<Node>)),
+  info?: string | ((completion: Completion) => (Node | Promise<Node | null>)),
   /// How to apply the completion. The default is to replace it with
   /// its [label](#autocomplete.Completion.label). When this holds a
   /// string, the completion range is replaced by that string. When it

--- a/src/tooltip.ts
+++ b/src/tooltip.ts
@@ -50,19 +50,15 @@ function optionContent(config: Required<CompletionConfig>): OptionContentSource[
   return content.sort((a, b) => a.position - b.position).map(a => a.render)
 }
 
-function createInfoDialog(option: Option, view: EditorView) {
+function createInfoDomNode(content: string | Node) {
   let dom = document.createElement("div")
   dom.className = "cm-tooltip cm-completionInfo"
-  let {info} = option.completion
-  if (typeof info == "string") {
-    dom.textContent = info
-  } else {
-    let content = info(option.completion)
-    if ('then' in content)
-      content.then(node => dom.appendChild(node), e => logException(view.state, e, "completion info"))
-    else
-      dom.appendChild(content)
-  }
+
+  if (typeof content === 'string')
+    dom.textContent = content
+  else
+    dom.appendChild(content)
+
   return dom
 }
 
@@ -138,14 +134,29 @@ class CompletionTooltip {
         if (this.info) this.view.requestMeasure(this.placeInfo)
       })
     }
-
     if (this.updateSelectedOption(open.selected)) {
       if (this.info) {this.info.remove(); this.info = null}
-      let option = open.options[open.selected]
-      if (option.completion.info) {
-        this.info = this.dom.appendChild(createInfoDialog(option, this.view)) as HTMLElement
+      let {completion} = open.options[open.selected]
+      let {info} = completion
+      if (!info) return
+      if (typeof info === 'string') {
+        this.info = this.dom.appendChild(createInfoDomNode(info))
         this.view.requestMeasure(this.placeInfo)
+        return;
       }
+      let infoResult = info(completion)
+      if ('then' in infoResult) {
+        infoResult.then(maybeNode => {
+          if (!maybeNode) return
+          let newState = this.view.state.field(this.stateField)
+          if (newState != cState) return
+          this.info = this.dom.appendChild(createInfoDomNode(maybeNode))
+          this.view.requestMeasure(this.placeInfo)
+        })
+        return
+      }
+      this.info = this.dom.appendChild(createInfoDomNode(infoResult))
+      this.view.requestMeasure(this.placeInfo)
     }
   }
 

--- a/src/tooltip.ts
+++ b/src/tooltip.ts
@@ -57,11 +57,11 @@ function createInfoDialog(option: Option, view: EditorView) {
   if (typeof info == "string") {
     dom.textContent = info
   } else {
-    let content = info!(option.completion)
-    if ((content as any).then)
-      (content as Promise<Node>).then(node => dom.appendChild(node), e => logException(view.state, e, "completion info"))
+    let content = info(option.completion)
+    if ('then' in content)
+      content.then(node => dom.appendChild(node), e => logException(view.state, e, "completion info"))
     else
-      dom.appendChild(content as Node)
+      dom.appendChild(content)
   }
   return dom
 }

--- a/src/tooltip.ts
+++ b/src/tooltip.ts
@@ -152,7 +152,7 @@ class CompletionTooltip {
           if (newState != cState) return
           this.info = this.dom.appendChild(createInfoDomNode(maybeNode))
           this.view.requestMeasure(this.placeInfo)
-        })
+        }).catch(e => logException(this.view.state, e, "completion info"))
         return
       }
       this.info = this.dom.appendChild(createInfoDomNode(infoResult))


### PR DESCRIPTION
It's possible to have `Completion.info` be a function that returns a node, it's also possible for that function to be async/return a promise. Sometimes you do async work and realize that you don't have extra completion information. An example of this is implementing [`completionItem/resolve`](https://microsoft.github.io/language-server-protocol/specification#completionItem_resolve), where the completion item might return no additional information to show. Currently we have to return a node and show a small useless square next to completion list.

This PR allows resolving the info to null.