### PR TITLE
RFC: Allow passing render function as Completion.detail

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -12,7 +12,7 @@ export interface Completion {
   label: string,
   /// An optional short piece of information to show (with a different
   /// style) after the label.
-  detail?: string,
+  detail?: string | ((completion: Completion) => (Node | null)),
   /// Additional info to show when the completion is selected. Can be
   /// a plain string or a function that'll render the DOM structure to
   /// show when invoked.

--- a/src/tooltip.ts
+++ b/src/tooltip.ts
@@ -40,10 +40,19 @@ function optionContent(config: Required<CompletionConfig>): OptionContentSource[
   }, {
     render(completion: Completion) {
       if (!completion.detail) return null
-      let detailElt = document.createElement("span")
-      detailElt.className = "cm-completionDetail"
-      detailElt.textContent = completion.detail
-      return detailElt
+      if (typeof completion.detail == 'function') {
+        let detail = completion.detail(completion)
+        if (!detail) return null
+        let detailElt = document.createElement("span")
+        detailElt.className = "cm-completionDetail"
+        detailElt.appendChild(detail)
+        return detailElt
+      } else {
+        let detailElt = document.createElement("span")
+        detailElt.className = "cm-completionDetail"
+        detailElt.textContent =  completion.detail
+        return detailElt
+      }
     },
     position: 80
   })


### PR DESCRIPTION
In some programming languages (BQN in this case, see screenshot) syntax highlighting encodes some semantic information and I'd want to present it in completion popups.

This PR allows to specify a render function as `Completion.detail` so arbitrary markup can be generated for the detail section of a completion item.

<img width="533" alt="Screenshot 2022-03-27 at 14 35 25" src="https://user-images.githubusercontent.com/30594/160279574-1ce1e5f2-9d1d-49a9-90eb-30321dfa4096.png">
