### PR TITLE
Deduplicating options: don't compare `type` fields if null

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -32,7 +32,8 @@ function sortOptions(active: readonly ActiveSource[], state: EditorState) {
   for (let opt of options.sort(cmpOption)) {
     if (result.length == MaxOptions) break
     if (!prev || prev.label != opt.completion.label || prev.detail != opt.completion.detail ||
-        prev.type != opt.completion.type || prev.apply != opt.completion.apply) result.push(opt)
+        (prev.type != null && opt.completion.type != null && prev.type != opt.completion.type) || 
+        prev.apply != opt.completion.apply) result.push(opt)
     else if (score(opt.completion) > score(prev)) result[result.length - 1] = opt
     prev = opt.completion
   }


### PR DESCRIPTION
Fix https://github.com/codemirror/codemirror.next/issues/788