### PR TITLE
Add aria-label to the listbox for autocomplete, for accessibility

### DIFF
--- a/src/tooltip.ts
+++ b/src/tooltip.ts
@@ -195,6 +195,7 @@ class CompletionTooltip {
     ul.id = id
     ul.setAttribute("role", "listbox")
     ul.setAttribute("aria-expanded", "true")
+    ul.setAttribute("aria-label", "autocomplete")
     for (let i = range.from; i < range.to; i++) {
       let {completion, match} = options[i]
       const li = ul.appendChild(document.createElement("li"))


### PR DESCRIPTION
Hi there!

I'm interested in adding an aria-label field for this autocomplete tooltip to meet the guidelines of this [accessibility check. ](https://dequeuniversity.com/rules/axe/4.3/aria-input-field-name?application=axeAPI)

Since the autocomplete is an input field, I propose providing it with an aria-label indicating that it's the input field for the autocomplete. What do you think?  