### PR TITLE
Declare state and view peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,11 @@
   "license": "MIT",
   "dependencies": {
     "@codemirror/language": "^6.0.0",
-    "@codemirror/state": "^6.0.0",
-    "@codemirror/view": "^6.0.0",
     "@lezer/common": "^1.0.0"
+  },
+  "peerDependencies": {
+    "@codemirror/state": "^6.0.0",
+    "@codemirror/view": "^6.0.0"
   },
   "devDependencies": {
     "@codemirror/buildhelper": "^0.1.5"


### PR DESCRIPTION
The user is going to need to put those into package.json themselves, whether it's by adding codemirror or @codemirror/view. As such there is no issue with those being peer dependencies.

See https://github.com/codemirror/dev/issues/858.