### PR TITLE
Allow completion detail to accept a Node

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -12,7 +12,7 @@ export interface Completion {
   label: string
   /// An optional short piece of information to show (with a different
   /// style) after the label.
-  detail?: string
+  detail?: string | Node
   /// Additional info to show when the completion is selected. Can be
   /// a plain string or a function that'll render the DOM structure to
   /// show when invoked.

--- a/src/tooltip.ts
+++ b/src/tooltip.ts
@@ -41,8 +41,12 @@ function optionContent(config: Required<CompletionConfig>): OptionContentSource[
     render(completion: Completion) {
       if (!completion.detail) return null
       let detailElt = document.createElement("span")
-      detailElt.className = "cm-completionDetail"
-      detailElt.textContent = completion.detail
+      detailElt.className = "cm-completionDetail"     
+      if (typeof completion.detail === "string") {
+        detailElt.textContent = completion.detail
+      } else {
+        detailElt.appendChild(completion.detail);
+      }
       return detailElt
     },
     position: 80

--- a/src/tooltip.ts
+++ b/src/tooltip.ts
@@ -41,7 +41,7 @@ function optionContent(config: Required<CompletionConfig>): OptionContentSource[
     render(completion: Completion) {
       if (!completion.detail) return null
       let detailElt = document.createElement("span")
-      detailElt.className = "cm-completionDetail"     
+      detailElt.className = "cm-completionDetail"
       if (typeof completion.detail === "string") {
         detailElt.textContent = completion.detail
       } else {


### PR DESCRIPTION
Allows more complex styling of the text inside the completion detail.