### PR TITLE
Bring back pickedCompletion annotation for apply: string | undefined

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -231,7 +231,8 @@ export function insertCompletionText(state: EditorState, text: string, from: num
         range: EditorSelection.cursor(range.from - len + text.length)
       }
     }),
-    userEvent: "input.complete"
+    userEvent: "input.complete",
+    annotations: pickedCompletion.of(option.completion)
   }
 }
 

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -231,8 +231,7 @@ export function insertCompletionText(state: EditorState, text: string, from: num
         range: EditorSelection.cursor(range.from - len + text.length)
       }
     }),
-    userEvent: "input.complete",
-    annotations: pickedCompletion.of(option.completion)
+    userEvent: "input.complete"
   }
 }
 
@@ -240,7 +239,10 @@ export function applyCompletion(view: EditorView, option: Option) {
   const apply = option.completion.apply || option.completion.label
   let result = option.source
   if (typeof apply == "string")
-    view.dispatch(insertCompletionText(view.state, apply, result.from, result.to))
+    view.dispatch({
+      ...insertCompletionText(view.state, apply, result.from, result.to),
+      annotations: pickedCompletion.of(option.completion)
+    })
   else
     apply(view, option.completion, result.from, result.to)
 }


### PR DESCRIPTION
In v0.20.0, the transaction generated by `applyCompletion` added the annotation `pickedCompletion.of(option.completion)` automatically. The docs suggest that this is intended:

https://github.com/codemirror/autocomplete/blob/83ba89266efa90b41b0bca23c2fb615b5c7e8346/src/completion.ts#L24-L26

This behaviour is missing in the current version (since https://github.com/codemirror/autocomplete/commit/758ecc3ba6638d38db8254a96871b90c0c9343a3), this PR adds it back.