### PR TITLE
Set box-sizing for border-box universal styles

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -90,7 +90,8 @@ export const baseTheme = EditorView.baseTheme({
     display: "inline-block",
     textAlign: "center",
     paddingRight: ".6em",
-    opacity: "0.6"
+    opacity: "0.6",
+    boxSizing: "content-box"
   },
 
   ".cm-completionIcon-function, .cm-completionIcon-method": {


### PR DESCRIPTION
When a universal CSS selector applies `box-sizing: border-box;` (which is a common pattern in CSS and commonly included in resets), the styling on the autocomplete icon is a bit broken:

`box-sizing: border-box`, key icon overlapping with text:

<img width="249" alt="Screenshot 2022-11-16 at 22 25 05" src="https://user-images.githubusercontent.com/1935696/202297706-9a7298bd-814f-41bc-9cd6-1971e5d6defb.png">

`box-sizing: content-box`, key icon not overlapping with text:

<img width="249" alt="Screenshot 2022-11-16 at 22 24 51" src="https://user-images.githubusercontent.com/1935696/202297716-4bdffb11-5fb7-479d-adbe-4e5239c2889f.png">

This PR ensures that the autocomplete icon will use the correct box sizing.

See also https://github.com/uiwjs/react-codemirror/issues/411, which this PR would resolve.