### PR TITLE
feat: snippet and snippetCompletion support custom placeholders

### DIFF
--- a/src/snippet.ts
+++ b/src/snippet.ts
@@ -250,8 +250,8 @@ const addSnippetKeymap = Prec.highest(keymap.compute([snippetKeymap], state => s
 /// Create a completion from a snippet. Returns an object with the
 /// properties from `completion`, plus an `apply` function that
 /// applies the snippet.
-export function snippetCompletion(template: string, completion: Completion): Completion {
-  return {...completion, apply: snippet(template)}
+export function snippetCompletion(template: string, completion: Completion, placeholder?: string): Completion {
+  return {...completion, apply: snippet(template, placeholder)}
 }
 
 const snippetPointerHandler = EditorView.domEventHandlers({


### PR DESCRIPTION
At present, snippet cannot customize the placeholder, I hope that the placeholder can be customized instead of the fixed # and $. Because in my business scenario, ${} and #{} will be rendered as a Widget.
After the snippet can be customized, I can write it like this:
`snippetCompletion('fun(${widget1}, @{p2}, @{p3})', Completion, '@')`
