### PR TITLE
Make sure snippet apply method adds input.complete user event

### DIFF
--- a/src/snippet.ts
+++ b/src/snippet.ts
@@ -171,7 +171,8 @@ export function snippet(template: string) {
     let spec: TransactionSpec = {
       changes: {from, to, insert: Text.of(text)},
       scrollIntoView: true,
-      annotations: completion ? pickedCompletion.of(completion) : undefined
+      annotations: completion ? pickedCompletion.of(completion) : undefined,
+      userEvent: "input.complete"
     }
     if (ranges.length) spec.selection = fieldSelection(ranges, 0)
     if (ranges.length > 1) {


### PR DESCRIPTION
The user event is added by `insertCompletionText`:

https://github.com/codemirror/autocomplete/blob/ffaa367319954cef49da50f4f42e60b876e4cc78/src/state.ts#L297-L303)

But the snippet apply doesn't add the event.