### PR TITLE
Adding option to configure debounce time

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -76,6 +76,10 @@ export interface CompletionConfig {
   /// displaying results from faster sources. Defaults to 100
   /// milliseconds.
   updateSyncTime?: number
+  /// This controls the minimum delay time in milliseconds before
+  /// before processing the latest input. Defaults to 500
+  /// milliseconds.
+  debounceTime?: number
 }
 
 export const completionConfig = Facet.define<CompletionConfig, Required<CompletionConfig>>({
@@ -95,7 +99,8 @@ export const completionConfig = Facet.define<CompletionConfig, Required<Completi
       positionInfo: defaultPositionInfo as any,
       compareCompletions: (a, b) => a.label.localeCompare(b.label),
       interactionDelay: 75,
-      updateSyncTime: 100
+      updateSyncTime: 100,
+      debounceTime: 500,
     }, {
       defaultKeymap: (a, b) => a && b,
       closeOnBlur: (a, b) => a && b,

--- a/src/config.ts
+++ b/src/config.ts
@@ -77,7 +77,7 @@ export interface CompletionConfig {
   /// milliseconds.
   updateSyncTime?: number
   /// This controls the minimum delay time in milliseconds before
-  /// before processing the latest input. Defaults to 500
+  /// before processing the latest input. Defaults to 50
   /// milliseconds.
   debounceTime?: number
 }
@@ -100,7 +100,7 @@ export const completionConfig = Facet.define<CompletionConfig, Required<Completi
       compareCompletions: (a, b) => a.label.localeCompare(b.label),
       interactionDelay: 75,
       updateSyncTime: 100,
-      debounceTime: 500,
+      debounceTime: 50,
     }, {
       defaultKeymap: (a, b) => a && b,
       closeOnBlur: (a, b) => a && b,

--- a/src/view.ts
+++ b/src/view.ts
@@ -103,7 +103,7 @@ export const completionPlugin = ViewPlugin.fromClass(class implements PluginValu
 
     if (this.debounceUpdate > -1) clearTimeout(this.debounceUpdate)
     this.debounceUpdate = cState.active.some(a => a.state == State.Pending && !this.running.some(q => q.active.source == a.source))
-      ? setTimeout(() => this.startUpdate(), 50) : -1
+      ? setTimeout(() => this.startUpdate(), this.view.state.facet(completionConfig).debounceTime) : -1
 
     if (this.composing != CompositionState.None) for (let tr of update.transactions) {
       if (getUserEvent(tr) == "input")


### PR DESCRIPTION
This PR proposes two updates:

Configurable Debounce Time:
- Current 50ms is too restrictive for certain use cases in our project. Adding an option to customize this value would enhance flexibility.

Revised Default Debounce Time:
- Based on [UX Stack Exchange insights](https://ux.stackexchange.com/questions/95336/how-long-should-the-debounce-timeout-be), a longer default debounce time might be more user-friendly. I suggest adjusting it to 500ms, improving user experience per community feedback.
For backward compatibility, we could retain the old default or consider other solutions.

Looking forward to your thoughts and suggestions.