### PR TITLE
pass Transaction to `validFor`

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -257,7 +257,7 @@ export class ActiveResult extends ActiveSource {
         type == "delete" && cur(tr.startState) == this.from)
       return new ActiveSource(this.source, type == "input" && conf.activateOnTyping ? State.Pending : State.Inactive)
     let explicitPos = this.explicitPos < 0 ? -1 : tr.changes.mapPos(this.explicitPos)
-    if (checkValid(result.validFor, tr, from, to, ))
+    if (checkValid(result.validFor, tr, from, to))
       return new ActiveResult(this.source, explicitPos, result, from, to)
     if (result.update &&
         (result = result.update(result, from, to, new CompletionContext(tr.state, pos, explicitPos >= 0))))
@@ -278,11 +278,11 @@ export class ActiveResult extends ActiveSource {
   }
 }
 
-function checkValid(validFor: undefined | RegExp | ((text: string, from: number, to: number, state: EditorState, tr: Transaction) => boolean),
+function checkValid(validFor: undefined | RegExp | ((text: string, from: number, to: number, state: EditorState) => boolean),
                     tr: Transaction, from: number, to: number) {
-  if (!validFor) return false
+  if (!validFor || tr.isUserEvent("input.complete")) return false
   let text = tr.state.sliceDoc(from, to)
-  return typeof validFor == "function" ? validFor(text, from, to, tr.state, tr) : ensureAnchor(validFor, true).test(text)
+  return typeof validFor == "function" ? validFor(text, from, to, tr.state) : ensureAnchor(validFor, true).test(text)
 }
 
 export const setActiveEffect = StateEffect.define<readonly ActiveSource[]>({

--- a/src/state.ts
+++ b/src/state.ts
@@ -257,7 +257,7 @@ export class ActiveResult extends ActiveSource {
         type == "delete" && cur(tr.startState) == this.from)
       return new ActiveSource(this.source, type == "input" && conf.activateOnTyping ? State.Pending : State.Inactive)
     let explicitPos = this.explicitPos < 0 ? -1 : tr.changes.mapPos(this.explicitPos)
-    if (checkValid(result.validFor, tr.state, from, to))
+    if (checkValid(result.validFor, tr, from, to, ))
       return new ActiveResult(this.source, explicitPos, result, from, to)
     if (result.update &&
         (result = result.update(result, from, to, new CompletionContext(tr.state, pos, explicitPos >= 0))))
@@ -278,11 +278,11 @@ export class ActiveResult extends ActiveSource {
   }
 }
 
-function checkValid(validFor: undefined | RegExp | ((text: string, from: number, to: number, state: EditorState) => boolean),
-                    state: EditorState, from: number, to: number) {
+function checkValid(validFor: undefined | RegExp | ((text: string, from: number, to: number, state: EditorState, tr: Transaction) => boolean),
+                    tr: Transaction, from: number, to: number) {
   if (!validFor) return false
-  let text = state.sliceDoc(from, to)
-  return typeof validFor == "function" ? validFor(text, from, to, state) : ensureAnchor(validFor, true).test(text)
+  let text = tr.state.sliceDoc(from, to)
+  return typeof validFor == "function" ? validFor(text, from, to, tr.state, tr) : ensureAnchor(validFor, true).test(text)
 }
 
 export const setActiveEffect = StateEffect.define<readonly ActiveSource[]>({


### PR DESCRIPTION
I'm using codemirror as a searchbox. I have two "types" of autocompletions:

1. Historical, i.e. previous things you've searched for.
2. Syntactical, i.e. typing `kind:` will give you different "kinds" of cards that you can search for.

I'm using [`activateOnCompletion`](https://github.com/AlexErrant/Pentive/blob/cba8d39e49953874831aa67457809a24fb120696/app/src/components/queryEditor.tsx#L103-L104) to get completion after accepting another completion. I'm also using [`validFor`](https://github.com/AlexErrant/Pentive/blob/cba8d39e49953874831aa67457809a24fb120696/shared-dom/src/language/queryCompletion.ts#L88) to make historical completions work since they may have spaces.

However, as seen in [this demo video](https://youtu.be/QK8tFUoMqAQ), the historical completion is "overriding" the syntactical completion because the `validFor` is still returning `true` even after the initial completion was accepted. You can play with the searchbox [here](https://app.pentive.com/cards).

This PR passes the Transaction to `validFor`. Using that transaction, I can call `tr.isUserEvent('input.complete')` and break out of `validFor`. I used pnpm patch to test this new behavior in [a branch of my project](https://github.com/AlexErrant/Pentive/compare/main...patch-autocomplete) and it works the way I want.