### PR TITLE
export startCompletionEffect and closeCompletionEffect

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {baseTheme} from "./theme"
 export {snippet, snippetCompletion, nextSnippetField, prevSnippetField,
         hasNextSnippetField, hasPrevSnippetField, clearSnippet, snippetKeymap} from "./snippet"
 export {Completion, CompletionInfo, CompletionSection, CompletionContext, CompletionSource, CompletionResult,
-        pickedCompletion, completeFromList, ifIn, ifNotIn, insertCompletionText} from "./completion"
+        pickedCompletion, completeFromList, ifIn, ifNotIn, insertCompletionText, startCompletionEffect, closeCompletionEffect} from "./completion"
 export {startCompletion, closeCompletion, acceptCompletion, moveCompletionSelection} from "./view"
 export {completeAnyWord} from "./word"
 export {CloseBracketConfig, closeBrackets, closeBracketsKeymap, deleteBracketPair, insertBracket} from "./closebrackets"


### PR DESCRIPTION
Trying to programmatically open the autocompletion menu when CodeMirror is empty and focused, as opposed to requiring a Ctrl+Space.

Would need to have state effects exported if I want to use https://codemirror.net/docs/ref/#state.EditorState^transactionExtender.

Work-around right now is using updateListener, and calling startCompletion.

```ts
EditorView.updateListener.of(
  ({ docChanged, view, state }) => {
    const shouldOpen = (docChanged || view.hasFocus) && !completionStatus(state);
    if (!state.doc.length && shouldOpen) {
      startCompletion(view);
    }
  }
)
```

This works but requires an additional check that completionState isn't already open to prevent an infinite loop of updates.

But I view this as more similar to the auto language example here https://codemirror.net/examples/config/