### PR TITLE
Export startCompletionEffect and closeCompletionEffect

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {baseTheme} from "./theme"
 export {snippet, snippetCompletion, nextSnippetField, prevSnippetField,
         hasNextSnippetField, hasPrevSnippetField, clearSnippet, snippetKeymap} from "./snippet"
 export {Completion, CompletionInfo, CompletionSection, CompletionContext, CompletionSource, CompletionResult,
-        pickedCompletion, completeFromList, ifIn, ifNotIn, insertCompletionText} from "./completion"
+        pickedCompletion, completeFromList, ifIn, ifNotIn, insertCompletionText, startCompletionEffect, closeCompletionEffect} from "./completion"
 export {startCompletion, closeCompletion, acceptCompletion, moveCompletionSelection} from "./view"
 export {completeAnyWord} from "./word"
 export {CloseBracketConfig, closeBrackets, closeBracketsKeymap, deleteBracketPair, insertBracket} from "./closebrackets"


### PR DESCRIPTION
This commit is exposing startCompletionEffect and closeCompletionEffect.
It allows us to modify StateFields whenever the completion popup opens/closes.