### PR TITLE
feat: only work with the last match in case where the regex contains global flag

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -123,7 +123,15 @@ export class CompletionContext {
     let line = this.state.doc.lineAt(this.pos)
     let start = Math.max(line.from, this.pos - 250)
     let str = line.text.slice(start - line.from, this.pos - line.from)
-    let found = str.search(ensureAnchor(expr, false))
+    let found = -1
+    if (expr.global) {
+      let match
+      /// Use the last match in case of a global expression.
+      while ((match = expr.exec(str)) !== null) found = match.index
+    } else {
+      found = str.search(ensureAnchor(expr, false))
+    }
+
     return found < 0 ? null : {from: start + found, to: this.pos, text: str.slice(found)}
   }
 


### PR DESCRIPTION
fixes: https://github.com/codemirror/dev/issues/1510

I have handled this explicitly for expressions with a global flag, but I feel the last match is _the_ match that should be used in every case here. 
The existing extra logic in `ensureAnchor` makes me believe there are some conditions that I might not be aware of, hence the explicit global case.