### PR TITLE
Make @codemirror/state a peerdependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,12 +27,15 @@
   "license": "MIT",
   "dependencies": {
     "@codemirror/language": "^6.0.0",
-    "@codemirror/state": "^6.0.0",
     "@codemirror/view": "^6.17.0",
     "@lezer/common": "^1.0.0"
   },
+  "peerDependencies": {
+    "@codemirror/state": "^6.0.0"
+  },
   "devDependencies": {
-    "@codemirror/buildhelper": "^1.0.0"
+    "@codemirror/buildhelper": "^1.0.0",
+    "@codemirror/state": "^6.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
It should only be installed once, so it's wrong to configure it as a dependency.

package managers like pnpm will install the dependency under autocomplete so you can end up with multiple installations of state which breaks codemirror